### PR TITLE
Fix shadow DOM removal deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.0] - 2018-02-05
+* Updated styles to remove deprecated shadow DOM elements
+  - see here for more info: http://blog.atom.io/2016/11/14/removing-shadow-dom-boundary-from-text-editor-elements.html
+
 ## 0.1.0 - First Release
 * Every feature added
 * Every bug fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nothrill-dark-syntax",
   "theme": "syntax",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "A fork of nofrils-dark",
   "keywords": [
     "syntax",
@@ -10,6 +10,6 @@
   "repository": "https://github.com/jonathanmh/nothrill-dark-syntax",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   }
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,6 +1,6 @@
 @import "syntax-variables";
 
-atom-text-editor, :host {
+atom-text-editor {
   background-color: @syntax-background-color;
   color: @syntax-text-color;
 
@@ -51,258 +51,255 @@ atom-text-editor, :host {
   }
 }
 
-atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: 1px solid @syntax-result-marker-color;
 }
 
-atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region {
   border: 1px solid @syntax-result-marker-color-selected;
 }
 
-.comment {
+.syntax--comment {
   color: @syntax-wrap-guide-color;
 }
 
-.keyword {
+.syntax--keyword {
   color: @syntax-text-color;
 
-  &.control {
+  &.syntax--control {
     color: @syntax-text-color;
   }
 
-  &.operator {
+  &.syntax--operator {
     color: @syntax-text-color;
   }
 
-  &.other.special-method {
+  &.syntax--other.syntax--special-method {
     color: @syntax-text-color;
   }
 
-  &.other.unit {
+  &.syntax--other.syntax--unit {
     color: @syntax-text-color;
   }
 }
 
-.storage {
+.syntax--storage {
   color: @syntax-text-color;
 }
 
-.constant {
+.syntax--constant {
   color: @syntax-text-color;
 
-  &.character.escape {
+  &.syntax--character.syntax--escape {
     color: @syntax-text-color;
   }
 
-  &.numeric {
+  &.syntax--numeric {
     color: @syntax-text-color;
   }
 
-  &.other.color {
+  &.syntax--other.syntax--color {
     color: @syntax-text-color;
   }
 
-  &.other.symbol {
-    color: @syntax-text-color;
-  }
-}
-
-.variable {
-  color: @syntax-text-color;
-
-  &.interpolation {
-    color: @syntax-text-color;
-  }
-
-  &.parameter.function {
+  &.syntax--other.syntax--symbol {
     color: @syntax-text-color;
   }
 }
 
-.invalid.illegal {
+.syntax--variable {
+  color: @syntax-text-color;
+
+  &.syntax--interpolation {
+    color: @syntax-text-color;
+  }
+
+  &.syntax--parameter.syntax--function {
+    color: @syntax-text-color;
+  }
+}
+
+.syntax--invalid.syntax--illegal {
   background-color: @red;
   color: @syntax-background-color;
 }
 
-.string {
+.syntax--string {
   color: @syntax-text-color;
 
 
-  &.regexp {
+  &.syntax--regexp {
     color: @syntax-text-color;
 
-    .source.ruby.embedded {
+    .syntax--source.syntax--ruby.syntax--embedded {
       color: @syntax-text-color;
     }
   }
 
-  &.other.link {
+  &.syntax--other.syntax--link {
     color: @red;
   }
 }
 
-.punctuation {
-  &.definition {
-    &.comment {
+.syntax--punctuation {
+  &.syntax--definition {
+    &.syntax--comment {
       color: @gray;
     }
 
-    &.string,
-    &.variable,
-    &.parameters,
-    &.array {
+    &.syntax--string,
+    &.syntax--variable,
+    &.syntax--parameters,
+    &.syntax--array {
       color: @syntax-text-color;
     }
 
-    &.heading,
-    &.identity {
+    &.syntax--heading,
+    &.syntax--identity {
       color: @syntax-text-color;
     }
 
-    &.bold {
+    &.syntax--bold {
       color: @syntax-text-color;
       font-weight: bold;
     }
 
-    &.italic {
+    &.syntax--italic {
       color: @syntax-text-color;
       font-style: italic;
     }
   }
 
-  &.section.embedded {
+  &.syntax--section.syntax--embedded {
     color: @syntax-text-color;
   }
 
 }
 
-.support {
-  &.class {
+.syntax--support {
+  &.syntax--class {
     color: @syntax-text-color;
   }
 
-  &.function  {
+  &.syntax--function  {
     color: @syntax-text-color;
 
-    &.any-method {
+    &.syntax--any-method {
       color: @syntax-text-color;
     }
   }
 }
 
-.entity {
-  &.name.function {
+.syntax--entity {
+  &.syntax--name.syntax--function {
     color: @syntax-text-color;
   }
-  &.name.type {
+  &.syntax--name.syntax--type {
     color: @syntax-text-color;
     text-decoration: underline;
   }
 
-  &.other.inherited-class {
+  &.syntax--other.syntax--inherited-class {
     color: @syntax-text-color;
   }
-  &.name.class, &.name.type.class {
-    color: @syntax-text-color;
-  }
-
-  &.name.section {
+  &.syntax--name.syntax--class, &.syntax--name.syntax--type.syntax--class {
     color: @syntax-text-color;
   }
 
-  &.name.tag {
+  &.syntax--name.syntax--section {
+    color: @syntax-text-color;
+  }
+
+  &.syntax--name.syntax--tag {
     color: @syntax-text-color;
     text-decoration: underline;
   }
 
-  &.other.attribute-name {
+  &.syntax--other.syntax--attribute-name {
     color: @syntax-text-color;
 
-    &.id {
+    &.syntax--id {
       color: @syntax-text-color;
     }
   }
 }
 
-.meta {
-  &.class {
+.syntax--meta {
+  &.syntax--class {
     color: @syntax-text-color;
   }
 
-  &.link {
+  &.syntax--link {
     color: @syntax-text-color;
   }
 
-  &.require {
+  &.syntax--require {
     color: @syntax-text-color;
   }
 
-  &.selector {
+  &.syntax--selector {
     color: @syntax-text-color;
   }
 
-  &.separator {
+  &.syntax--separator {
     background-color: @gray;
     color: @syntax-text-color;
   }
 }
 
-.none {
+.syntax--none {
   color: @syntax-text-color;
 }
 
-.markup {
-  &.bold {
+.syntax--markup {
+  &.syntax--bold {
     color: @syntax-text-color;
     font-weight: bold;
   }
 
-  &.changed {
+  &.syntax--changed {
     color: @syntax-text-color;
   }
 
-  &.deleted {
+  &.syntax--deleted {
     color: @syntax-text-color;
   }
 
-  &.italic {
+  &.syntax--italic {
     color: @syntax-text-color;
     font-style: italic;
   }
 
-  &.heading .punctuation.definition.heading {
+  &.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading {
     color: @syntax-text-color;
   }
 
-  &.inserted {
+  &.syntax--inserted {
     color: @syntax-text-color;
   }
 
-  &.list {
+  &.syntax--list {
     color: @syntax-text-color;
   }
 
-  &.quote {
+  &.syntax--quote {
     color: @syntax-text-color;
   }
 
-  &.raw.inline {
+  &.syntax--raw.syntax--inline {
     color: @syntax-text-color;
   }
 }
 
-.source.gfm .markup {
+.syntax--source.syntax--gfm .syntax--markup {
   -webkit-font-smoothing: auto;
-  &.heading {
+  &.syntax--heading {
     color: @syntax-text-color;
   }
 }
 
-atom-text-editor[mini] .scroll-view,
-:host([mini]) .scroll-view {
+atom-text-editor[mini] .scroll-view {
   padding-left: 1px;
 }
 
@@ -314,7 +311,7 @@ atom-text-editor[mini] .scroll-view,
 
 // matching brackets are shown with inverted selection colours
 // actually for now, this isn't working properly, because of the cursor half transparencyness
-.editor, atom-text-editor::shadow {
+.editor {
   .bracket-matcher {
     border-bottom: none;
     position: absolute;


### PR DESCRIPTION
This removes any `:host` and `:shadow` references and prepends `syntax--` to all the elements that require it.

This stops you getting deprecation warnings in atom.

I've updated the version requirement of atom to reflect the changes.